### PR TITLE
patch ant 'dist' to target assembly.plugin.dir

### DIFF
--- a/localmetadata/build.properties
+++ b/localmetadata/build.properties
@@ -13,7 +13,7 @@ plugin.dir.name = ${plugin.name}.bundle
 plugin.src.dir = ${plugin.dir.name}
 plugin.src.code.dir = code
 # This should be the upcoming (an unreleased) version.
-plugin.version = 0.3
+plugin.version = 0.3.1
 plugin.docs.dir = docs
 
 build.dir = build

--- a/localmetadata/build.xml
+++ b/localmetadata/build.xml
@@ -48,14 +48,14 @@
     <property name="plugin.base.filename" value="${plugin.name}-${plugin.version}" />
     <property name="plugin.zip.filepath" value="${build.dist.dir}/${plugin.base.filename}.zip" />
     <zip destfile="${plugin.zip.filepath}" update="true">
-      <zipfileset dir="${plugin.src.dir}" prefix="${plugin.dir.name}" />
+      <zipfileset dir="${build.assembly.plugin.dir}" prefix="${plugin.dir.name}" />
       <fileset dir="${plugin.docs.dir}" />
       <file file="../README.md" />
       <file file="../LICENSE" />
     </zip>
     <property name="plugin.gz.filepath" value="${build.dist.dir}/${plugin.base.filename}.tar.gz" />
     <tar destfile="${plugin.gz.filepath}" compression="gzip">
-      <zipfileset dir="${plugin.src.dir}" prefix="${plugin.dir.name}" />
+      <zipfileset dir="${build.assembly.plugin.dir}" prefix="${plugin.dir.name}" />
       <fileset dir="${plugin.docs.dir}" />
       <file file="../README.md" />
       <file file="../LICENSE" />


### PR DESCRIPTION
resolves #1 

updated the ant build scripts per @beeradmoore findings

@mrzhenya: this is my first time using ant, let me know if anything looks off. I didn't update the zip and tar in the release folder since ant wasn't automating that portion. I will let you update the 0.2 releases accordingly.

Thanks for the plugin BTW! 